### PR TITLE
use stack to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 *.swp
 *.o
 *.hi
+.stack-work/

--- a/README.md
+++ b/README.md
@@ -29,15 +29,17 @@ Of course not.
 So, here comes `sjsp`, a tool for injecting profiling codes into JavaScript files.
 
 ## Installation
+
+Prepare `stack` command to download it from [here](https://github.com/commercialhaskell/stack/releases) and then run the following script:
+
 ```
  $ git clone https://github.com/itchyny/sjsp
  $ cd sjsp
- $ sudo cabal install
+ $ stack install
 ```
 
-When you failed to install with the error `The program happy version >=x.xx is required but it could not be found.`, add the path to the environment variable.
 ```
-export PATH=$PATH:$HOME/.cabal/bin
+export PATH=$PATH:$HOME/.local/bin
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ function test() {
   var start_time = Date.now(); // grab the current time at the top
 
   // our code
-  
+
   log_profile("test", Date.now() - start_time); // grab the current time again and log the time the function consumed.
 }
 ```
@@ -29,6 +29,23 @@ Of course not.
 So, here comes `sjsp`, a tool for injecting profiling codes into JavaScript files.
 
 ## Installation
+
+There are two ways to build sjsp; cabal-install and stack. If you have not Haskell environment yet, stack is a simpler way.
+
+### cabal-install
+
+```
+ $ git clone https://github.com/itchyny/sjsp
+ $ cd sjsp
+ $ sudo cabal install
+```
+
+When you failed to install with the error `The program happy version >=x.xx is required but it could not be found.`, add the path to the environment variable.
+```
+export PATH=$PATH:$HOME/.cabal/bin
+```
+
+### stack
 
 Prepare `stack` command to download it from [here](https://github.com/commercialhaskell/stack/releases) and then run the following script:
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: nightly-2015-07-01


### PR DESCRIPTION
I make [`stack`](https://github.com/commercialhaskell/stack) used to build.

`stack` is very useful. If you use `stack`, no need to prepare GHC, cabal-install and so on manually. `stack` downloads them and dependency packages and then build sjsp.
