### PR TITLE
Fix initial number of counter

### DIFF
--- a/src/Injector.hs
+++ b/src/Injector.hs
@@ -99,7 +99,7 @@ profiler config node = NN $ JSExpression [ fromRight $ flip parse "" $
          , identifier "end" ++ " = function(x) {"
          , "  if (!x.time) return;"
          , "  var key = x.fname + ' :: ' + x.line + ' :: ' + x.col; "
-         , "  " ++ identifier "result" ++ "[key] = " ++ identifier "result" ++ "[key] || { count: 1, time: 0, line: x.line, col: x.col, name: x.name, fname: x.fname, linestr: x.linestr }; "
+         , "  " ++ identifier "result" ++ "[key] = " ++ identifier "result" ++ "[key] || { count: 0, time: 0, line: x.line, col: x.col, name: x.name, fname: x.fname, linestr: x.linestr }; "
          , "  " ++ identifier "result" ++ "[key].time += (Date.now() - x.time); "
          , "  " ++ identifier "result" ++ "[key].count += 1; "
          , "}; "


### PR DESCRIPTION
I made a javascript file such that

```
function test(){ } // test.js
```

and HTML file like below.

```
<!-- test.html -->
<script>test();</script>
<script src="test.js"></script>
```

But I got

```
========== SORT BY TIME ==========
test.sjsp.js:1 time:    0.00sec   count:       2         test.js           test   (line:   1, col: 16)   function test(){ }
========== SORT BY COUNT ==========
test.sjsp.js:1 time:    0.00sec   count:       2         test.js           test   (line:   1, col: 16)   function test(){ }
```

I think number of count is not `2` but `1`.
(In the source code, the initial number of counter is `1` and incremented after that.)

After fix, the number works correctly.
